### PR TITLE
feat: add example of managing env variables

### DIFF
--- a/EnvVariables/EnvVariables.sln
+++ b/EnvVariables/EnvVariables.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnvVariables", "EnvVariables\EnvVariables.csproj", "{F7A4CF28-1AC0-489E-A189-AAD5FD128311}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7A4CF28-1AC0-489E-A189-AAD5FD128311}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7A4CF28-1AC0-489E-A189-AAD5FD128311}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7A4CF28-1AC0-489E-A189-AAD5FD128311}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7A4CF28-1AC0-489E-A189-AAD5FD128311}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
+++ b/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
@@ -2,7 +2,7 @@
 
 public static class ConfigurationBuilderExtensions
 {
-    public static IConfigurationBuilder AddEnvSubstitution(
+    public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
         params EnvVariable[] envVariables
@@ -11,7 +11,7 @@ public static class ConfigurationBuilderExtensions
         return builder.ConfigureCore(loggerFactory, envVariables);
     }
 
-    public static IConfigurationBuilder AddEnvSubstitution(
+    public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
         IReadOnlyCollection<EnvVariable> envVariables
@@ -20,15 +20,15 @@ public static class ConfigurationBuilderExtensions
         return builder.ConfigureCore(loggerFactory, envVariables);
     }
 
-    private static IConfigurationBuilder ConfigureCore(
+    private static EnvSubstitutionConfigurationProvider ConfigureCore(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
         IReadOnlyCollection<EnvVariable> envVariables
     )
     {
-        var source = new EnvSubstitutionConfigurationSource(
-            loggerFactory,
-            envVariables
+        var source = new EnvSubstitutionConfigurationProvider(
+            envVariables,
+            loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>()
         );
 
         var args = Environment.GetCommandLineArgs();
@@ -40,6 +40,8 @@ public static class ConfigurationBuilderExtensions
             Environment.Exit(0);
         }
 
-        return builder.Add(source);
+        builder.Add(source);
+
+        return source;
     }
 }

--- a/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
+++ b/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
@@ -2,36 +2,14 @@
 
 public static class ConfigurationBuilderExtensions
 {
-    public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
+    public static IEnvVariablesProvider AddEnvVariables(
         this IConfigurationBuilder builder,
-        ILoggerFactory loggerFactory,
-        Func<IEnumerable<EnvVariable>>? dynamicVariables = null,
-        params EnvVariable[] envVariables
-    )
-    {
-        return builder.ConfigureCore(loggerFactory, envVariables, dynamicVariables);
-    }
-
-    public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
-        this IConfigurationBuilder builder,
-        ILoggerFactory loggerFactory,
-        IReadOnlyCollection<EnvVariable> envVariables,
-        Func<IEnumerable<EnvVariable>>? dynamicVariables = null
-    )
-    {
-        return builder.ConfigureCore(loggerFactory, envVariables, dynamicVariables);
-    }
-
-    private static EnvSubstitutionConfigurationProvider ConfigureCore(
-        this IConfigurationBuilder builder,
-        ILoggerFactory loggerFactory,
-        IReadOnlyCollection<EnvVariable> envVariables,
+        IReadOnlyCollection<EnvVariable>? envVariables = null,
         Func<IEnumerable<EnvVariable>>? dynamicVariables = null
     )
     {
         var source = new EnvSubstitutionConfigurationProvider(
-            envVariables,
-            loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>(),
+            envVariables ?? [],
             dynamicVariables
         );
 

--- a/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
+++ b/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,45 @@
+﻿namespace EnvVariables;
+
+public static class ConfigurationBuilderExtensions
+{
+    public static IConfigurationBuilder AddEnvSubstitution(
+        this IConfigurationBuilder builder,
+        ILoggerFactory loggerFactory,
+        params EnvVariable[] envVariables
+    )
+    {
+        return builder.ConfigureCore(loggerFactory, envVariables);
+    }
+
+    public static IConfigurationBuilder AddEnvSubstitution(
+        this IConfigurationBuilder builder,
+        ILoggerFactory loggerFactory,
+        IReadOnlyCollection<EnvVariable> envVariables
+    )
+    {
+        return builder.ConfigureCore(loggerFactory, envVariables);
+    }
+
+    private static IConfigurationBuilder ConfigureCore(
+        this IConfigurationBuilder builder,
+        ILoggerFactory loggerFactory,
+        IReadOnlyCollection<EnvVariable> envVariables
+    )
+    {
+        var source = new EnvSubstitutionConfigurationSource(
+            loggerFactory,
+            envVariables
+        );
+
+        var args = Environment.GetCommandLineArgs();
+
+        if (args.Contains("print-envs"))
+        {
+            source.PrintEnvs();
+
+            Environment.Exit(0);
+        }
+
+        return builder.Add(source);
+    }
+}

--- a/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
+++ b/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
@@ -5,30 +5,34 @@ public static class ConfigurationBuilderExtensions
     public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
+        Func<IEnumerable<EnvVariable>>? dynamicVariables = null,
         params EnvVariable[] envVariables
     )
     {
-        return builder.ConfigureCore(loggerFactory, envVariables);
+        return builder.ConfigureCore(loggerFactory, envVariables, dynamicVariables);
     }
 
     public static EnvSubstitutionConfigurationProvider AddEnvSubstitution(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
-        IReadOnlyCollection<EnvVariable> envVariables
+        IReadOnlyCollection<EnvVariable> envVariables,
+        Func<IEnumerable<EnvVariable>>? dynamicVariables = null
     )
     {
-        return builder.ConfigureCore(loggerFactory, envVariables);
+        return builder.ConfigureCore(loggerFactory, envVariables, dynamicVariables);
     }
 
     private static EnvSubstitutionConfigurationProvider ConfigureCore(
         this IConfigurationBuilder builder,
         ILoggerFactory loggerFactory,
-        IReadOnlyCollection<EnvVariable> envVariables
+        IReadOnlyCollection<EnvVariable> envVariables,
+        Func<IEnumerable<EnvVariable>>? dynamicVariables = null
     )
     {
         var source = new EnvSubstitutionConfigurationProvider(
             envVariables,
-            loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>()
+            loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>(),
+            dynamicVariables
         );
 
         builder.Add(source);

--- a/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
+++ b/EnvVariables/EnvVariables/ConfigurationBuilderExtensions.cs
@@ -31,15 +31,6 @@ public static class ConfigurationBuilderExtensions
             loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>()
         );
 
-        var args = Environment.GetCommandLineArgs();
-
-        if (args.Contains("print-envs"))
-        {
-            source.PrintEnvs();
-
-            Environment.Exit(0);
-        }
-
         builder.Add(source);
 
         return source;

--- a/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
+++ b/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
@@ -4,11 +4,15 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
 {
     private readonly ILogger _logger;
     private readonly HashSet<EnvVariable> _envVariables;
+    private readonly Func<IEnumerable<EnvVariable>>? _dynamicVariables;
 
-    public IReadOnlyCollection<EnvVariable> EnvVariables => _envVariables;
-
-    public EnvSubstitutionConfigurationProvider(IReadOnlyCollection<EnvVariable> envVariables, ILogger logger)
+    public EnvSubstitutionConfigurationProvider(
+        IReadOnlyCollection<EnvVariable> envVariables,
+        ILogger logger,
+        Func<IEnumerable<EnvVariable>>? dynamicVariables = null
+    )
     {
+        _dynamicVariables = dynamicVariables;
         _logger = logger;
         _envVariables = new HashSet<EnvVariable>(envVariables.Count);
 
@@ -26,7 +30,7 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
     {
         var errors = new List<string>();
 
-        foreach (var envVariable in _envVariables)
+        foreach (var envVariable in GetAllVariables())
         {
             var value = Environment.GetEnvironmentVariable(envVariable.Name) ?? envVariable.DefaultValue;
 
@@ -48,9 +52,14 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
         }
     }
 
+    public IEnumerable<EnvVariable> GetAllVariables()
+    {
+        return _envVariables.Concat(_dynamicVariables?.Invoke() ?? []);
+    }
+
     public void PrintEnvs()
     {
-        _logger.LogInformation("{@EnvVariables}", _envVariables);
+        _logger.LogInformation("{@EnvVariables}", GetAllVariables());
     }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)

--- a/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
+++ b/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
@@ -1,26 +1,25 @@
 ﻿namespace EnvVariables;
 
-public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider, IConfigurationSource
+internal sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider, IConfigurationSource, IEnvVariablesProvider
 {
-    private readonly ILogger _logger;
     private readonly HashSet<EnvVariable> _envVariables;
     private readonly Func<IEnumerable<EnvVariable>>? _dynamicVariables;
 
     public EnvSubstitutionConfigurationProvider(
         IReadOnlyCollection<EnvVariable> envVariables,
-        ILogger logger,
         Func<IEnumerable<EnvVariable>>? dynamicVariables = null
     )
     {
         _dynamicVariables = dynamicVariables;
-        _logger = logger;
-        _envVariables = new HashSet<EnvVariable>(envVariables.Count);
+        _envVariables = new HashSet<EnvVariable>(envVariables.Count, EnvVariable.NameComparer);
 
         AddVariables(envVariables);
     }
 
-    public void Add(params EnvVariable[] envVariables)
+    public void Add(IReadOnlyCollection<EnvVariable> envVariables)
     {
+        ArgumentNullException.ThrowIfNull(envVariables);
+
         AddVariables(envVariables);
         Load();
         OnReload();
@@ -28,16 +27,22 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
 
     public override void Load()
     {
-        var errors = new List<string>();
+        var errors = new Dictionary<string, string>();
 
-        foreach (var envVariable in GetAllVariables())
+        foreach (var envVariable in GetAll())
         {
             var value = Environment.GetEnvironmentVariable(envVariable.Name) ?? envVariable.DefaultValue;
 
-            if (!envVariable.Validate(value, out var errorMessage))
+            try
             {
-                _logger.LogCritical(errorMessage);
-                errors.Add(errorMessage);
+                if (!envVariable.Validate(value, out var errorMessage))
+                {
+                    errors.TryAdd(envVariable.Name, errorMessage);
+                }
+            }
+            catch (Exception e)
+            {
+                errors.TryAdd(envVariable.Name, "Failed to validate environment variable: " + e.Message);
             }
 
             foreach (var section in envVariable.PopulateTo)
@@ -48,18 +53,13 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
 
         if (errors.Count != 0)
         {
-            throw new InvalidOperationException($"Environment variable validation failed: {string.Join("; ", errors)}");
+            throw new InvalidEnvVariablesException("Found errors in environment variables", errors);
         }
     }
 
-    public IEnumerable<EnvVariable> GetAllVariables()
+    public IEnumerable<EnvVariable> GetAll()
     {
         return _envVariables.Concat(_dynamicVariables?.Invoke() ?? []);
-    }
-
-    public void PrintEnvs()
-    {
-        _logger.LogInformation("{@EnvVariables}", GetAllVariables());
     }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
@@ -73,7 +73,7 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
         {
             if (!_envVariables.Add(envVariable))
             {
-                var env = _envVariables.Single(x => x == envVariable);
+                var env = _envVariables.Single(x => EnvVariable.NameComparer.Equals(x, envVariable));
                 env.MergeWith(envVariable);
             }
         }

--- a/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
+++ b/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
@@ -1,14 +1,24 @@
 ﻿namespace EnvVariables;
 
-public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
+public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider, IConfigurationSource
 {
     private readonly ILogger _logger;
-    private readonly IReadOnlyCollection<EnvVariable> _envVariables;
+    private readonly HashSet<EnvVariable> _envVariables;
 
-    public EnvSubstitutionConfigurationProvider(ILogger logger, IReadOnlyCollection<EnvVariable> envVariables)
+    public EnvSubstitutionConfigurationProvider(IReadOnlyCollection<EnvVariable> envVariables, ILogger logger)
     {
         _logger = logger;
-        _envVariables = envVariables;
+        _envVariables = new HashSet<EnvVariable>(envVariables);
+    }
+
+    public void Add(params EnvVariable[] envVariables)
+    {
+        foreach (var envVariable in envVariables)
+        {
+            _envVariables.Add(envVariable);
+        }
+        Load();
+        OnReload();
     }
 
     public override void Load()
@@ -35,36 +45,24 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
             Environment.Exit(1);
         }
     }
-}
 
-public sealed class EnvSubstitutionConfigurationSource : IConfigurationSource
-{
-    private readonly ILoggerFactory _loggerFactory;
-    private readonly IReadOnlyCollection<EnvVariable> _mapping;
-
-    public EnvSubstitutionConfigurationSource(
-        ILoggerFactory loggerFactory,
-        IReadOnlyCollection<EnvVariable> mapping
-    )
+    public void PrintEnvs()
     {
-        _loggerFactory = loggerFactory;
-        _mapping = mapping;
+        _logger.LogInformation("Printing configured env variables:");
+
+        foreach (var envVariable in _envVariables)
+        {
+            _logger.LogInformation("{@EnvVariable}", envVariable);
+        }
+    }
+
+    public IReadOnlyCollection<EnvVariable> GetEnvs()
+    {
+        return _envVariables;
     }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
-        return new EnvSubstitutionConfigurationProvider(_loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>(), _mapping);
-    }
-
-    public void PrintEnvs()
-    {
-        var logger = _loggerFactory.CreateLogger<EnvSubstitutionConfigurationSource>();
-
-        logger.LogInformation("Printing configured env variables:");
-
-        foreach (var envVariable in _mapping)
-        {
-            logger.LogInformation("{@EnvVariable}", envVariable);
-        }
+        return this;
     }
 }

--- a/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
+++ b/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
@@ -5,33 +5,35 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
     private readonly ILogger _logger;
     private readonly HashSet<EnvVariable> _envVariables;
 
+    public IReadOnlyCollection<EnvVariable> EnvVariables => _envVariables;
+
     public EnvSubstitutionConfigurationProvider(IReadOnlyCollection<EnvVariable> envVariables, ILogger logger)
     {
         _logger = logger;
-        _envVariables = new HashSet<EnvVariable>(envVariables);
+        _envVariables = new HashSet<EnvVariable>(envVariables.Count);
+
+        AddVariables(envVariables);
     }
 
     public void Add(params EnvVariable[] envVariables)
     {
-        foreach (var envVariable in envVariables)
-        {
-            _envVariables.Add(envVariable);
-        }
+        AddVariables(envVariables);
         Load();
         OnReload();
     }
 
     public override void Load()
     {
-        var hasErrors = false;
+        var errors = new List<string>();
+
         foreach (var envVariable in _envVariables)
         {
             var value = Environment.GetEnvironmentVariable(envVariable.Name) ?? envVariable.DefaultValue;
 
             if (!envVariable.Validate(value, out var errorMessage))
             {
-                _logger.LogCritical(errorMessage, envVariable.Name);
-                hasErrors = true;
+                _logger.LogCritical(errorMessage);
+                errors.Add(errorMessage);
             }
 
             foreach (var section in envVariable.PopulateTo)
@@ -40,29 +42,31 @@ public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
             }
         }
 
-        if (hasErrors)
+        if (errors.Count != 0)
         {
-            Environment.Exit(1);
+            throw new InvalidOperationException($"Environment variable validation failed: {string.Join("; ", errors)}");
         }
     }
 
     public void PrintEnvs()
     {
-        _logger.LogInformation("Printing configured env variables:");
-
-        foreach (var envVariable in _envVariables)
-        {
-            _logger.LogInformation("{@EnvVariable}", envVariable);
-        }
-    }
-
-    public IReadOnlyCollection<EnvVariable> GetEnvs()
-    {
-        return _envVariables;
+        _logger.LogInformation("{@EnvVariables}", _envVariables);
     }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
         return this;
+    }
+
+    private void AddVariables(IReadOnlyCollection<EnvVariable> envVariables)
+    {
+        foreach (var envVariable in envVariables)
+        {
+            if (!_envVariables.Add(envVariable))
+            {
+                var env = _envVariables.Single(x => x == envVariable);
+                env.MergeWith(envVariable);
+            }
+        }
     }
 }

--- a/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
+++ b/EnvVariables/EnvVariables/EnvSubstitutionConfigurationProvider.cs
@@ -1,0 +1,70 @@
+﻿namespace EnvVariables;
+
+public sealed class EnvSubstitutionConfigurationProvider : ConfigurationProvider
+{
+    private readonly ILogger _logger;
+    private readonly IReadOnlyCollection<EnvVariable> _envVariables;
+
+    public EnvSubstitutionConfigurationProvider(ILogger logger, IReadOnlyCollection<EnvVariable> envVariables)
+    {
+        _logger = logger;
+        _envVariables = envVariables;
+    }
+
+    public override void Load()
+    {
+        var hasErrors = false;
+        foreach (var envVariable in _envVariables)
+        {
+            var value = Environment.GetEnvironmentVariable(envVariable.Name) ?? envVariable.DefaultValue;
+
+            if (!envVariable.Validate(value, out var errorMessage))
+            {
+                _logger.LogCritical(errorMessage, envVariable.Name);
+                hasErrors = true;
+            }
+
+            foreach (var section in envVariable.PopulateTo)
+            {
+                Data[section] = value;
+            }
+        }
+
+        if (hasErrors)
+        {
+            Environment.Exit(1);
+        }
+    }
+}
+
+public sealed class EnvSubstitutionConfigurationSource : IConfigurationSource
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IReadOnlyCollection<EnvVariable> _mapping;
+
+    public EnvSubstitutionConfigurationSource(
+        ILoggerFactory loggerFactory,
+        IReadOnlyCollection<EnvVariable> mapping
+    )
+    {
+        _loggerFactory = loggerFactory;
+        _mapping = mapping;
+    }
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        return new EnvSubstitutionConfigurationProvider(_loggerFactory.CreateLogger<EnvSubstitutionConfigurationProvider>(), _mapping);
+    }
+
+    public void PrintEnvs()
+    {
+        var logger = _loggerFactory.CreateLogger<EnvSubstitutionConfigurationSource>();
+
+        logger.LogInformation("Printing configured env variables:");
+
+        foreach (var envVariable in _mapping)
+        {
+            logger.LogInformation("{@EnvVariable}", envVariable);
+        }
+    }
+}

--- a/EnvVariables/EnvVariables/EnvVariable.cs
+++ b/EnvVariables/EnvVariables/EnvVariable.cs
@@ -1,90 +1,22 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace EnvVariables;
 
-public delegate bool EnvVariableValidation(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage);
-
-public class EnvVariableBuilder
+/// <summary>
+/// Environment variable.
+/// </summary>
+[DebuggerDisplay("DebuggerDisplayString()")]
+public class EnvVariable
 {
-    private readonly string _name;
-    private string _description;
-    private HashSet<string>? _populateTo;
-    private bool _required;
-    private string? _defaultValue;
+    internal static IEqualityComparer<EnvVariable> NameComparer { get; } = new NameEqualityComparer();
 
-    public EnvVariableBuilder(string name)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(nameof(name));
-
-        _name = name;
-        _required = true;
-    }
-
-    public static EnvVariableBuilder Required(string name)
-    {
-        return new EnvVariableBuilder(name).AsRequired();
-    }
-
-    public static EnvVariableBuilder Optional(string name)
-    {
-        return new EnvVariableBuilder(name).AsOptional();
-    }
-
-    public EnvVariableBuilder WithDescription(string description)
-    {
-        _description = description;
-
-        return this;
-    }
-
-    public EnvVariableBuilder WithDefaultValue(string? defaultValue)
-    {
-        _defaultValue = defaultValue;
-
-        return this;
-    }
-
-    public EnvVariableBuilder WithPopulateTo(params string[] populateTo)
-    {
-        _populateTo = new HashSet<string>(populateTo);
-
-        return this;
-    }
-
-    public EnvVariableBuilder AsRequired()
-    {
-        _required = true;
-
-        return this;
-    }
-
-    public EnvVariableBuilder AsOptional()
-    {
-        _required = false;
-
-        return this;
-    }
-
-    public EnvVariable Build()
-    {
-        return new EnvVariable(_name, _description, _populateTo, _required, _defaultValue);
-    }
-
-    public static implicit operator EnvVariable(EnvVariableBuilder builder)
-    {
-        return builder.Build();
-    }
-}
-
-
-public class EnvVariable : IEquatable<EnvVariable>
-{
-    private EnvVariableValidation _customValidation;
+    private Func<string?, string?> _customValidation;
     private readonly HashSet<string> _populateTo;
 
     public string Name { get; }
 
-    public string? Description { get; }
+    public string? Description { get; private set; }
 
     public IReadOnlyCollection<string> PopulateTo => _populateTo;
 
@@ -98,7 +30,7 @@ public class EnvVariable : IEquatable<EnvVariable>
         IReadOnlyCollection<string>? populateTo = null,
         bool required = true,
         string? defaultValue = null,
-        EnvVariableValidation? customValidation = null
+        Func<string?, string?>? customValidation = null
     )
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -111,11 +43,16 @@ public class EnvVariable : IEquatable<EnvVariable>
         _customValidation = customValidation ?? DefaultValidation;
     }
 
+    public override string ToString()
+    {
+        return Name;
+    }
+
     internal void MergeWith(EnvVariable envVariable)
     {
-        if (this != envVariable)
+        if (!NameComparer.Equals(this, envVariable))
         {
-            throw new InvalidOperationException("Cannot merge envs with different names");
+            throw new InvalidOperationException($"Cannot merge envs with different names [{envVariable.Name} -> {Name}]");
         }
 
         if (_customValidation != DefaultValidation && envVariable._customValidation != DefaultValidation)
@@ -125,9 +62,14 @@ public class EnvVariable : IEquatable<EnvVariable>
 
         Required |= envVariable.Required;
 
-        if (!string.IsNullOrWhiteSpace(envVariable.DefaultValue) && string.IsNullOrWhiteSpace(envVariable.DefaultValue))
+        if (!string.IsNullOrWhiteSpace(envVariable.DefaultValue) && string.IsNullOrWhiteSpace(DefaultValue))
         {
             DefaultValue = envVariable.DefaultValue;
+        }
+
+        if (!string.IsNullOrWhiteSpace(envVariable.Description) && string.IsNullOrWhiteSpace(Description))
+        {
+            Description = envVariable.Description;
         }
 
         _populateTo.UnionWith(envVariable.PopulateTo);
@@ -139,73 +81,58 @@ public class EnvVariable : IEquatable<EnvVariable>
         }
     }
 
-    public bool Validate(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    internal bool Validate(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
     {
-        return _customValidation(value, out errorMessage);
+        errorMessage = _customValidation(value);
+
+        return string.IsNullOrWhiteSpace(errorMessage);
     }
 
-    public bool Equals(EnvVariable? other)
-    {
-        if (other is null)
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        if (obj is null)
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, obj))
-        {
-            return true;
-        }
-
-        if (obj.GetType() != GetType())
-        {
-            return false;
-        }
-
-        return Equals((EnvVariable)obj);
-    }
-
-    public override int GetHashCode()
-    {
-        return StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
-    }
-
-    public static bool operator ==(EnvVariable? left, EnvVariable? right)
-    {
-        return Equals(left, right);
-    }
-
-    public static bool operator !=(EnvVariable? left, EnvVariable? right)
-    {
-        return !Equals(left, right);
-    }
-
-    private bool DefaultValidation(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    private string? DefaultValidation(string? value)
     {
         if (Required && string.IsNullOrWhiteSpace(value))
         {
-
-            errorMessage = $"Environment variable {Name} is missing";
-
-            return false;
+            return $"Environment variable {Name} is missing";
         }
 
-        errorMessage = null;
+        return null;
+    }
 
-        return true;
+    private string DebuggerDisplayString()
+    {
+        return Name +
+               (Required
+                   ? "*"
+                   : "") +
+               " = " +
+               (Environment.GetEnvironmentVariable(Name) ?? DefaultValue);
+    }
+
+    private sealed class NameEqualityComparer : IEqualityComparer<EnvVariable>
+    {
+        public bool Equals(EnvVariable? x, EnvVariable? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (x.GetType() != y.GetType())
+            {
+                return false;
+            }
+
+            return string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(EnvVariable obj)
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name);
+        }
     }
 }

--- a/EnvVariables/EnvVariables/EnvVariable.cs
+++ b/EnvVariables/EnvVariables/EnvVariable.cs
@@ -2,63 +2,79 @@
 
 namespace EnvVariables;
 
-public class RequiredVariable : EnvVariable
-{
-    public RequiredVariable(
-        string name,
-        string[] populateTo,
-        string? defaultValue = null
-    ) : base(name, populateTo, required: true, defaultValue)
-    {
-    }
-}
-
-public class OptionalVariable : EnvVariable
-{
-    public OptionalVariable(
-        string name,
-        string[] populateTo,
-        string? defaultValue = null
-    ) : base(name, populateTo, required: false, defaultValue)
-    {
-    }
-}
+public delegate bool EnvVariableValidation(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage);
 
 public class EnvVariable : IEquatable<EnvVariable>
 {
-    public string Name { get; init; }
+    private EnvVariableValidation _customValidation;
+    private readonly HashSet<string> _populateTo;
 
-    public string[] PopulateTo { get; init; }
+    public string Name { get; }
 
-    public bool Required { get; init; }
+    public IReadOnlyCollection<string> PopulateTo => _populateTo;
 
-    public string? DefaultValue { get; init; }
+    public bool Required { get; private set; }
+
+    public string? DefaultValue { get; private set; }
 
     public EnvVariable(
         string name,
-        string[] populateTo,
-        bool required,
-        string? defaultValue
+        IReadOnlyCollection<string>? populateTo = null,
+        bool required = true,
+        string? defaultValue = null,
+        EnvVariableValidation? customValidation = null
     )
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        _populateTo = new HashSet<string>(populateTo ?? []);
         Name = name;
-        PopulateTo = populateTo;
         Required = required;
         DefaultValue = defaultValue;
+        _customValidation = customValidation ?? DefaultValidation;
     }
 
-    public virtual bool Validate(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    public static EnvVariable AsRequired(string name, string[]? populateTo = null, string? defaultValue = null)
     {
-        if (!Required || !string.IsNullOrWhiteSpace(value))
-        {
-            errorMessage = null;
+        return new EnvVariable(name, populateTo, required: true, defaultValue);
+    }
 
-            return true;
+    public static EnvVariable AsOptional(string name, string[]? populateTo = null, string? defaultValue = null)
+    {
+        return new EnvVariable(name, populateTo, required: false, defaultValue);
+    }
+
+    public void MergeWith(EnvVariable envVariable)
+    {
+        if (this != envVariable)
+        {
+            throw new InvalidOperationException("Cannot merge envs with different names");
         }
 
-        errorMessage = "Environment variable {Name} is missing";
+        if (_customValidation != DefaultValidation && envVariable._customValidation != DefaultValidation)
+        {
+            throw new InvalidOperationException("Cannot merge envs with different custom validations");
+        }
 
-        return false;
+        Required |= envVariable.Required;
+
+        if (!string.IsNullOrWhiteSpace(envVariable.DefaultValue) && string.IsNullOrWhiteSpace(envVariable.DefaultValue))
+        {
+            DefaultValue = envVariable.DefaultValue;
+        }
+
+        _populateTo.UnionWith(envVariable.PopulateTo);
+
+        // default validation might be replaced with custom
+        if (_customValidation == DefaultValidation && envVariable._customValidation != envVariable.DefaultValidation)
+        {
+            _customValidation = envVariable._customValidation;
+        }
+    }
+
+    public bool Validate(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    {
+        return _customValidation(value, out errorMessage);
     }
 
     public bool Equals(EnvVariable? other)
@@ -109,5 +125,20 @@ public class EnvVariable : IEquatable<EnvVariable>
     public static bool operator !=(EnvVariable? left, EnvVariable? right)
     {
         return !Equals(left, right);
+    }
+
+    private bool DefaultValidation(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    {
+        if (Required && string.IsNullOrWhiteSpace(value))
+        {
+
+            errorMessage = $"Environment variable {Name} is missing";
+
+            return false;
+        }
+
+        errorMessage = null;
+
+        return true;
     }
 }

--- a/EnvVariables/EnvVariables/EnvVariable.cs
+++ b/EnvVariables/EnvVariables/EnvVariable.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EnvVariables;
+
+public class RequiredVariable : EnvVariable
+{
+    public RequiredVariable(
+        string name,
+        string[] populateTo,
+        string? defaultValue = null
+    ) : base(name, populateTo, required: true, defaultValue)
+    {
+    }
+}
+
+public class OptionalVariable : EnvVariable
+{
+    public OptionalVariable(
+        string name,
+        string[] populateTo,
+        string? defaultValue = null
+    ) : base(name, populateTo, required: false, defaultValue)
+    {
+    }
+}
+
+public class EnvVariable
+{
+    public string Name { get; init; }
+
+    public string[] PopulateTo { get; init; }
+
+    public bool Required { get; init; }
+
+    public string? DefaultValue { get; init; }
+
+    public EnvVariable(
+        string name,
+        string[] populateTo,
+        bool required,
+        string? defaultValue
+    )
+    {
+        Name = name;
+        PopulateTo = populateTo;
+        Required = required;
+        DefaultValue = defaultValue;
+    }
+
+    public virtual bool Validate(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage)
+    {
+        if (!Required || !string.IsNullOrWhiteSpace(value))
+        {
+            errorMessage = null;
+
+            return true;
+        }
+
+        errorMessage = "Environment variable {Name} is missing";
+
+        return false;
+    }
+}

--- a/EnvVariables/EnvVariables/EnvVariable.cs
+++ b/EnvVariables/EnvVariables/EnvVariable.cs
@@ -4,12 +4,87 @@ namespace EnvVariables;
 
 public delegate bool EnvVariableValidation(string? value, [NotNullWhen(returnValue: false)] out string? errorMessage);
 
+public class EnvVariableBuilder
+{
+    private readonly string _name;
+    private string _description;
+    private HashSet<string>? _populateTo;
+    private bool _required;
+    private string? _defaultValue;
+
+    public EnvVariableBuilder(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nameof(name));
+
+        _name = name;
+        _required = true;
+    }
+
+    public static EnvVariableBuilder Required(string name)
+    {
+        return new EnvVariableBuilder(name).AsRequired();
+    }
+
+    public static EnvVariableBuilder Optional(string name)
+    {
+        return new EnvVariableBuilder(name).AsOptional();
+    }
+
+    public EnvVariableBuilder WithDescription(string description)
+    {
+        _description = description;
+
+        return this;
+    }
+
+    public EnvVariableBuilder WithDefaultValue(string? defaultValue)
+    {
+        _defaultValue = defaultValue;
+
+        return this;
+    }
+
+    public EnvVariableBuilder WithPopulateTo(params string[] populateTo)
+    {
+        _populateTo = new HashSet<string>(populateTo);
+
+        return this;
+    }
+
+    public EnvVariableBuilder AsRequired()
+    {
+        _required = true;
+
+        return this;
+    }
+
+    public EnvVariableBuilder AsOptional()
+    {
+        _required = false;
+
+        return this;
+    }
+
+    public EnvVariable Build()
+    {
+        return new EnvVariable(_name, _description, _populateTo, _required, _defaultValue);
+    }
+
+    public static implicit operator EnvVariable(EnvVariableBuilder builder)
+    {
+        return builder.Build();
+    }
+}
+
+
 public class EnvVariable : IEquatable<EnvVariable>
 {
     private EnvVariableValidation _customValidation;
     private readonly HashSet<string> _populateTo;
 
     public string Name { get; }
+
+    public string? Description { get; }
 
     public IReadOnlyCollection<string> PopulateTo => _populateTo;
 
@@ -19,6 +94,7 @@ public class EnvVariable : IEquatable<EnvVariable>
 
     public EnvVariable(
         string name,
+        string? description = null,
         IReadOnlyCollection<string>? populateTo = null,
         bool required = true,
         string? defaultValue = null,
@@ -29,22 +105,13 @@ public class EnvVariable : IEquatable<EnvVariable>
 
         _populateTo = new HashSet<string>(populateTo ?? []);
         Name = name;
+        Description = description;
         Required = required;
         DefaultValue = defaultValue;
         _customValidation = customValidation ?? DefaultValidation;
     }
 
-    public static EnvVariable AsRequired(string name, string[]? populateTo = null, string? defaultValue = null)
-    {
-        return new EnvVariable(name, populateTo, required: true, defaultValue);
-    }
-
-    public static EnvVariable AsOptional(string name, string[]? populateTo = null, string? defaultValue = null)
-    {
-        return new EnvVariable(name, populateTo, required: false, defaultValue);
-    }
-
-    public void MergeWith(EnvVariable envVariable)
+    internal void MergeWith(EnvVariable envVariable)
     {
         if (this != envVariable)
         {

--- a/EnvVariables/EnvVariables/EnvVariable.cs
+++ b/EnvVariables/EnvVariables/EnvVariable.cs
@@ -24,7 +24,7 @@ public class OptionalVariable : EnvVariable
     }
 }
 
-public class EnvVariable
+public class EnvVariable : IEquatable<EnvVariable>
 {
     public string Name { get; init; }
 
@@ -59,5 +59,55 @@ public class EnvVariable
         errorMessage = "Environment variable {Name} is missing";
 
         return false;
+    }
+
+    public bool Equals(EnvVariable? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != GetType())
+        {
+            return false;
+        }
+
+        return Equals((EnvVariable)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+    }
+
+    public static bool operator ==(EnvVariable? left, EnvVariable? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(EnvVariable? left, EnvVariable? right)
+    {
+        return !Equals(left, right);
     }
 }

--- a/EnvVariables/EnvVariables/EnvVariableBuilder.cs
+++ b/EnvVariables/EnvVariables/EnvVariableBuilder.cs
@@ -1,0 +1,81 @@
+﻿namespace EnvVariables;
+
+public class EnvVariableBuilder
+{
+    private readonly string _name;
+    private string? _description;
+    private HashSet<string>? _populateTo;
+    private bool _required;
+    private string? _defaultValue;
+    private Func<string?, string?>? _customValidator;
+
+    public EnvVariableBuilder(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        _name = name;
+        _required = true;
+    }
+
+    public static EnvVariableBuilder Required(string name)
+    {
+        return new EnvVariableBuilder(name).AsRequired();
+    }
+
+    public static EnvVariableBuilder Optional(string name)
+    {
+        return new EnvVariableBuilder(name).AsOptional();
+    }
+
+    public EnvVariableBuilder WithDescription(string description)
+    {
+        _description = description;
+
+        return this;
+    }
+
+    public EnvVariableBuilder WithDefaultValue(string? defaultValue)
+    {
+        _defaultValue = defaultValue;
+
+        return this;
+    }
+
+    public EnvVariableBuilder WithPopulateTo(params string[] populateTo)
+    {
+        _populateTo = new HashSet<string>(populateTo);
+
+        return this;
+    }
+
+    public EnvVariableBuilder WithCustomValidation(Func<string?, string?>? customValidator)
+    {
+        _customValidator = customValidator;
+
+        return this;
+    }
+
+    public EnvVariableBuilder AsRequired()
+    {
+        _required = true;
+
+        return this;
+    }
+
+    public EnvVariableBuilder AsOptional()
+    {
+        _required = false;
+
+        return this;
+    }
+
+    public EnvVariable Build()
+    {
+        return new EnvVariable(_name, _description, _populateTo, _required, _defaultValue, _customValidator);
+    }
+
+    public static implicit operator EnvVariable(EnvVariableBuilder builder)
+    {
+        return builder.Build();
+    }
+}

--- a/EnvVariables/EnvVariables/EnvVariables.csproj
+++ b/EnvVariables/EnvVariables/EnvVariables.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <RootNamespace>EnvVariables</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2"/>
+        <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/EnvVariables/EnvVariables/IEnvVariablesProvider.cs
+++ b/EnvVariables/EnvVariables/IEnvVariablesProvider.cs
@@ -1,0 +1,18 @@
+﻿namespace EnvVariables;
+
+/// <summary>
+/// Provider of <see cref="EnvVariable"/>.
+/// </summary>
+public interface IEnvVariablesProvider
+{
+    /// <summary>
+    /// Adds env variables.
+    /// </summary>
+    /// <param name="envVariables">Env variables.</param>
+    void Add(IReadOnlyCollection<EnvVariable> envVariables);
+
+    /// <summary>
+    /// Returns all registered variables.
+    /// </summary>
+    IEnumerable<EnvVariable> GetAll();
+}

--- a/EnvVariables/EnvVariables/InvalidEnvVariablesException.cs
+++ b/EnvVariables/EnvVariables/InvalidEnvVariablesException.cs
@@ -1,0 +1,20 @@
+﻿namespace EnvVariables;
+
+public sealed class InvalidEnvVariablesException : Exception
+{
+    public IReadOnlyDictionary<string, string> Errors { get; }
+
+    public InvalidEnvVariablesException(string message, IReadOnlyDictionary<string, string> errors)
+        : base(message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        ArgumentNullException.ThrowIfNull(errors);
+
+        Errors = errors;
+    }
+
+    public override string ToString()
+    {
+        return Message + " " + string.Join(", ", Errors.Select(x => $"{x.Key}: {x.Value}"));
+    }
+}

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -51,16 +51,27 @@ try
 
     app.MapGet("/", ([FromServices] IConfiguration config) =>
     {
-        return Results.Ok(new[]
+        var additionals = new[]
         {
-            config["my:deep:section:value"],
-            config["my:deep:anotherSection:value"],
-            config["top_level_value"],
-            config["my:deep:section:additionalPropertyAlsoWorks"],
-            config["my:additionalPropertyAlsoWorks"],
-            config["some:feature:value"],
-            config["one:more:section:value"]
-        });
+            "my:deep:section:additionalPropertyAlsoWorks",
+            "my:additionalPropertyAlsoWorks"
+        };
+
+        var result = new Dictionary<string, string?>();
+        foreach (var envVariable in source.GetEnvs())
+        {
+            foreach (var p in envVariable.PopulateTo)
+            {
+                result[p] = config[p] + $" -> [from env variable {envVariable.Name}]";
+            }
+        }
+
+        foreach (var additional in additionals)
+        {
+            result[additional] = config[additional];
+        }
+
+        return Results.Ok(result);
     });
 
     // easy to get configured variables

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using EnvVariables;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using Serilog.Context;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 
@@ -19,36 +20,49 @@ try
     builder.Logging.ClearProviders();
 
     var logger = new LoggerConfiguration()
-        .MinimumLevel.Is(LogEventLevel.Information)
-        .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-        .Enrich.FromLogContext()
-        .WriteTo.Console(new JsonFormatter())
-        .ReadFrom.Configuration(builder.Configuration)
+        .MinimumLevel
+        .Is(LogEventLevel.Information)
+        .MinimumLevel
+        .Override("Microsoft", LogEventLevel.Information)
+        .Enrich
+        .FromLogContext()
+        .WriteTo
+        .Console(new JsonFormatter())
+        .ReadFrom
+        .Configuration(builder.Configuration)
         .CreateLogger();
 
     builder.Logging.AddSerilog(logger);
 
     var envs = new List<EnvVariable>
     {
-        EnvVariableBuilder.Required("REQUIRED_VARIABLE")
+        EnvVariableBuilder
+            .Required("REQUIRED_VARIABLE")
             .WithDescription("Example of required variable")
             .WithPopulateTo("my:deep:section:value", "my:deep:anotherSection:value"),
-        EnvVariableBuilder.Optional("NOT_REQUIRED_VARIABLE")
+        EnvVariableBuilder
+            .Optional("NOT_REQUIRED_VARIABLE")
             .WithDescription("Example of optional variable")
             .WithPopulateTo("top_level_value"),
     };
 
     // we can dynamically add variables, that depends on some static feature flags
-    if (string.Equals(Environment.GetEnvironmentVariable("SOME_STATIC_FEATURE_ENABLED"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    if (string.Equals(Environment.GetEnvironmentVariable("SOME_STATIC_FEATURE_ENABLED"), bool.TrueString,
+            StringComparison.OrdinalIgnoreCase))
     {
-        envs.Add(EnvVariableBuilder.Required("STATIC_FEATURE_VARIABLE").WithDescription("static env variable").WithPopulateTo("some:static_feature:value"));
+        envs.Add(EnvVariableBuilder
+            .Required("STATIC_FEATURE_VARIABLE")
+            .WithDescription("static env variable")
+            .WithPopulateTo("some:static_feature:value"));
 
         // we can add same variable multiple times and set different populateTo (they will be merged)
-        envs.Add(EnvVariableBuilder.Required("STATIC_FEATURE_VARIABLE").WithDescription("static env variable").WithPopulateTo("some:static_feature:value2"));
+        envs.Add(EnvVariableBuilder
+            .Required("STATIC_FEATURE_VARIABLE")
+            .WithDescription("static env variable")
+            .WithPopulateTo("some:static_feature:value2"));
     }
 
-    var source = builder.Configuration.AddEnvSubstitution(
-        LoggerFactory.Create(o => o.AddSerilog(logger)),
+    var envVariablesProvider = builder.Configuration.AddEnvVariables(
         envs,
         dynamicVariables: () =>
         {
@@ -71,7 +85,12 @@ try
         });
 
     // also, we can add it later after registration
-    source.Add(EnvVariableBuilder.Required("ONE_MORE_VARIABLE").WithDescription("one more!").WithPopulateTo("one:more:section:value"));
+    envVariablesProvider.Add([
+        EnvVariableBuilder
+            .Required("ONE_MORE_VARIABLE")
+            .WithDescription("one more!")
+            .WithPopulateTo("one:more:section:value")
+    ]);
 
     var app = builder.Build();
 
@@ -84,7 +103,7 @@ try
         };
 
         var result = new Dictionary<string, string?>();
-        foreach (var envVariable in source.GetAllVariables())
+        foreach (var envVariable in envVariablesProvider.GetAll())
         {
             foreach (var p in envVariable.PopulateTo)
             {
@@ -101,33 +120,49 @@ try
     });
 
     // easy to get configured variables
-    app.MapGet("/envs", () => source.GetAllVariables());
+    app.MapGet("/envs", () => envVariablesProvider.GetAll());
 
+    // for print envs to logs via dotnet run -- print-envs
     if (args.Any(a => a.Equals("print-envs", StringComparison.OrdinalIgnoreCase)))
     {
-        source.PrintEnvs();
-        Environment.Exit(0);
+        foreach (var envVariable in envVariablesProvider.GetAll())
+        {
+            app.Logger.LogInformation("@{EnvVariable}", envVariable);
+        }
+
+        return 0;
     }
 
+    // for save envs to file via dotnet run -- save-envs
     if (args.Any(a => a.Equals("save-envs", StringComparison.OrdinalIgnoreCase)))
     {
         var opt = new JsonSerializerOptions { WriteIndented = true };
         await File.WriteAllBytesAsync(
-                "./envs.json",
-                JsonSerializer.SerializeToUtf8Bytes(
-                    source.GetAllVariables().OrderBy(x => x.Name),
-                    options: opt
-                )
-            );
+            "./envs.json",
+            JsonSerializer.SerializeToUtf8Bytes(
+                envVariablesProvider.GetAll().OrderBy(x => x.Name),
+                options: opt
+            )
+        );
 
-        Environment.Exit(0);
+        return 0;
     }
 
     app.Run();
+
+    return 0;
+}
+catch (InvalidEnvVariablesException e)
+{
+    Log.Fatal("Failed to start app. {Message} [{Errors}]", e.Message, e.Errors);
+
+    return 1;
 }
 catch (Exception e)
 {
     Log.Fatal(e, "Application terminated unexpectedly");
+
+    return 1;
 }
 finally
 {

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using EnvVariables;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
@@ -29,17 +30,21 @@ try
 
     var envs = new List<EnvVariable>
     {
-        EnvVariable.AsRequired(name: "REQUIRED_VARIABLE", populateTo: ["my:deep:section:value", "my:deep:anotherSection:value"]),
-        EnvVariable.AsOptional(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
+        EnvVariableBuilder.Required("REQUIRED_VARIABLE")
+            .WithDescription("Example of required variable")
+            .WithPopulateTo("my:deep:section:value", "my:deep:anotherSection:value"),
+        EnvVariableBuilder.Optional("NOT_REQUIRED_VARIABLE")
+            .WithDescription("Example of optional variable")
+            .WithPopulateTo("top_level_value"),
     };
 
     // we can dynamically add variables, that depends on some static feature flags
     if (string.Equals(Environment.GetEnvironmentVariable("SOME_STATIC_FEATURE_ENABLED"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
     {
-        envs.Add(EnvVariable.AsRequired("STATIC_FEATURE_VARIABLE", populateTo: ["some:static_feature:value"]));
+        envs.Add(EnvVariableBuilder.Required("STATIC_FEATURE_VARIABLE").WithDescription("static env variable").WithPopulateTo("some:static_feature:value"));
 
         // we can add same variable multiple times and set different populateTo (they will be merged)
-        envs.Add(EnvVariable.AsRequired("STATIC_FEATURE_VARIABLE", populateTo: ["some:static_feature:value2"]));
+        envs.Add(EnvVariableBuilder.Required("STATIC_FEATURE_VARIABLE").WithDescription("static env variable").WithPopulateTo("some:static_feature:value2"));
     }
 
     var source = builder.Configuration.AddEnvSubstitution(
@@ -54,15 +59,19 @@ try
                     bool.TrueString,
                     StringComparison.OrdinalIgnoreCase))
             {
-                dynamicEnvs.Add(EnvVariable.AsRequired("DYNAMIC_FEATURE_VARIABLE",
-                    populateTo: ["some:dynamic_feature:value"]));
+
+                dynamicEnvs.Add(EnvVariableBuilder
+                    .Optional("DYNAMIC_FEATURE_VARIABLE")
+                    .WithDescription("Dynamic feature variable")
+                    .WithPopulateTo("some:dynamic_feature:value")
+                );
             }
 
             return dynamicEnvs;
         });
 
     // also, we can add it later after registration
-    source.Add(EnvVariable.AsRequired("ONE_MORE_VARIABLE", populateTo: ["one:more:section:value"]));
+    source.Add(EnvVariableBuilder.Required("ONE_MORE_VARIABLE").WithDescription("one more!").WithPopulateTo("one:more:section:value"));
 
     var app = builder.Build();
 
@@ -97,6 +106,20 @@ try
     if (args.Any(a => a.Equals("print-envs", StringComparison.OrdinalIgnoreCase)))
     {
         source.PrintEnvs();
+        Environment.Exit(0);
+    }
+
+    if (args.Any(a => a.Equals("save-envs", StringComparison.OrdinalIgnoreCase)))
+    {
+        var opt = new JsonSerializerOptions { WriteIndented = true };
+        await File.WriteAllBytesAsync(
+                "./envs.json",
+                JsonSerializer.SerializeToUtf8Bytes(
+                    source.GetAllVariables().OrderBy(x => x.Name),
+                    options: opt
+                )
+            );
+
         Environment.Exit(0);
     }
 

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -29,14 +29,17 @@ try
 
     var envs = new List<EnvVariable>
     {
-        new RequiredVariable(name: "REQUIRED_VARIABLE", populateTo: ["my:deep:section:value", "my:deep:anotherSection:value"]),
-        new OptionalVariable(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
+        EnvVariable.AsRequired(name: "REQUIRED_VARIABLE", populateTo: ["my:deep:section:value", "my:deep:anotherSection:value"]),
+        EnvVariable.AsOptional(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
     };
 
     // we can dynamically add variables, that depends on some feature flags
     if (builder.Configuration.GetValue("SOME_FEATURE_ENABLED", true))
     {
-        envs.Add(new RequiredVariable("FEATURE_VARIABLE", populateTo: ["some:feature:value"]));
+        envs.Add(EnvVariable.AsRequired("FEATURE_VARIABLE", populateTo: ["some:feature:value"]));
+
+        // we can add same variable multiple times and set different populateTo (they will be merged)
+        envs.Add(EnvVariable.AsRequired("FEATURE_VARIABLE", populateTo: ["some:feature:value2"]));
     }
 
     var source = builder.Configuration.AddEnvSubstitution(
@@ -45,7 +48,7 @@ try
     );
 
     // also, we can add it later after registration
-    source.Add(new RequiredVariable("ONE_MORE_VARIABLE", populateTo: ["one:more:section:value"]));
+    source.Add(EnvVariable.AsRequired("ONE_MORE_VARIABLE", populateTo: ["one:more:section:value"]));
 
     var app = builder.Build();
 
@@ -58,7 +61,7 @@ try
         };
 
         var result = new Dictionary<string, string?>();
-        foreach (var envVariable in source.GetEnvs())
+        foreach (var envVariable in source.EnvVariables)
         {
             foreach (var p in envVariable.PopulateTo)
             {
@@ -75,7 +78,13 @@ try
     });
 
     // easy to get configured variables
-    app.MapGet("/envs", () => source.GetEnvs());
+    app.MapGet("/envs", () => source.EnvVariables);
+
+    if (args.Any(a => a.Equals("print-envs", StringComparison.OrdinalIgnoreCase)))
+    {
+        source.PrintEnvs();
+        Environment.Exit(0);
+    }
 
     app.Run();
 }

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -33,19 +33,33 @@ try
         EnvVariable.AsOptional(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
     };
 
-    // we can dynamically add variables, that depends on some feature flags
-    if (builder.Configuration.GetValue("SOME_FEATURE_ENABLED", true))
+    // we can dynamically add variables, that depends on some static feature flags
+    if (string.Equals(Environment.GetEnvironmentVariable("SOME_STATIC_FEATURE_ENABLED"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
     {
-        envs.Add(EnvVariable.AsRequired("FEATURE_VARIABLE", populateTo: ["some:feature:value"]));
+        envs.Add(EnvVariable.AsRequired("STATIC_FEATURE_VARIABLE", populateTo: ["some:static_feature:value"]));
 
         // we can add same variable multiple times and set different populateTo (they will be merged)
-        envs.Add(EnvVariable.AsRequired("FEATURE_VARIABLE", populateTo: ["some:feature:value2"]));
+        envs.Add(EnvVariable.AsRequired("STATIC_FEATURE_VARIABLE", populateTo: ["some:static_feature:value2"]));
     }
 
     var source = builder.Configuration.AddEnvSubstitution(
         LoggerFactory.Create(o => o.AddSerilog(logger)),
-        envs
-    );
+        envs,
+        dynamicVariables: () =>
+        {
+            var dynamicEnvs = new List<EnvVariable>();
+
+            // imagine here your dynamic feature flag check
+            if (string.Equals(Environment.GetEnvironmentVariable("SOME_DYNAMIC_FEATURE_ENABLED"),
+                    bool.TrueString,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                dynamicEnvs.Add(EnvVariable.AsRequired("DYNAMIC_FEATURE_VARIABLE",
+                    populateTo: ["some:dynamic_feature:value"]));
+            }
+
+            return dynamicEnvs;
+        });
 
     // also, we can add it later after registration
     source.Add(EnvVariable.AsRequired("ONE_MORE_VARIABLE", populateTo: ["one:more:section:value"]));
@@ -61,7 +75,7 @@ try
         };
 
         var result = new Dictionary<string, string?>();
-        foreach (var envVariable in source.EnvVariables)
+        foreach (var envVariable in source.GetAllVariables())
         {
             foreach (var p in envVariable.PopulateTo)
             {
@@ -78,7 +92,7 @@ try
     });
 
     // easy to get configured variables
-    app.MapGet("/envs", () => source.EnvVariables);
+    app.MapGet("/envs", () => source.GetAllVariables());
 
     if (args.Any(a => a.Equals("print-envs", StringComparison.OrdinalIgnoreCase)))
     {

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -1,0 +1,70 @@
+using EnvVariables;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Is(LogEventLevel.Information)
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+    .Enrich.FromLogContext()
+    .WriteTo.Console(new JsonFormatter())
+    .CreateBootstrapLogger();
+
+try
+{
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.Logging.ClearProviders();
+
+    var logger = new LoggerConfiguration()
+        .MinimumLevel.Is(LogEventLevel.Information)
+        .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+        .Enrich.FromLogContext()
+        .WriteTo.Console(new JsonFormatter())
+        .ReadFrom.Configuration(builder.Configuration)
+        .CreateLogger();
+
+    builder.Logging.AddSerilog(logger);
+
+    var envs = new List<EnvVariable>
+    {
+        new RequiredVariable(name: "REQUIRED_VARIABLE", populateTo: ["my:deep:section:value", "my:deep:anotherSection:value"]),
+        new OptionalVariable(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
+    };
+
+    if (builder.Configuration.GetValue("SOME_FEATURE_ENABLED", true))
+    {
+        envs.Add(new RequiredVariable("FEATURE_VARIABLE", populateTo: ["some:feature:value"]));
+    }
+
+    builder.Configuration.AddEnvSubstitution(
+        LoggerFactory.Create(o => o.AddSerilog(logger)),
+        envs
+    );
+
+    var app = builder.Build();
+
+    app.MapGet("/", ([FromServices] IConfiguration config) =>
+    {
+        return Results.Ok(new[]
+        {
+            config["my:deep:section:value"],
+            config["my:deep:anotherSection:value"],
+            config["top_level_value"],
+            config["my:deep:section:additionalPropertyAlsoWorks"],
+            config["my:additionalPropertyAlsoWorks"],
+            config["some:feature:value"]
+        });
+    });
+
+    app.Run();
+}
+catch (Exception e)
+{
+    Log.Fatal(e, "Application terminated unexpectedly");
+}
+finally
+{
+    await Log.CloseAndFlushAsync();
+}

--- a/EnvVariables/EnvVariables/Program.cs
+++ b/EnvVariables/EnvVariables/Program.cs
@@ -33,15 +33,19 @@ try
         new OptionalVariable(name: "NOT_REQUIRED_VARIABLE", populateTo: ["top_level_value"])
     };
 
+    // we can dynamically add variables, that depends on some feature flags
     if (builder.Configuration.GetValue("SOME_FEATURE_ENABLED", true))
     {
         envs.Add(new RequiredVariable("FEATURE_VARIABLE", populateTo: ["some:feature:value"]));
     }
 
-    builder.Configuration.AddEnvSubstitution(
+    var source = builder.Configuration.AddEnvSubstitution(
         LoggerFactory.Create(o => o.AddSerilog(logger)),
         envs
     );
+
+    // also, we can add it later after registration
+    source.Add(new RequiredVariable("ONE_MORE_VARIABLE", populateTo: ["one:more:section:value"]));
 
     var app = builder.Build();
 
@@ -54,9 +58,13 @@ try
             config["top_level_value"],
             config["my:deep:section:additionalPropertyAlsoWorks"],
             config["my:additionalPropertyAlsoWorks"],
-            config["some:feature:value"]
+            config["some:feature:value"],
+            config["one:more:section:value"]
         });
     });
+
+    // easy to get configured variables
+    app.MapGet("/envs", () => source.GetEnvs());
 
     app.Run();
 }

--- a/EnvVariables/EnvVariables/Properties/launchSettings.json
+++ b/EnvVariables/EnvVariables/Properties/launchSettings.json
@@ -10,9 +10,11 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "REQUIRED_VARIABLE": "required variable value",
         "NOT_REQUIRED_VARIABLE": "not required variable value",
-        "SOME_FEATURE_ENABLED": "true",
-        "FEATURE_VARIABLE": "feature var",
-        "ONE_MORE_VARIABLE": "ONE_MORE"
+        "SOME_STATIC_FEATURE_ENABLED": "true",
+        "STATIC_FEATURE_VARIABLE": "feature var",
+        "ONE_MORE_VARIABLE": "ONE_MORE",
+        "SOME_DYNAMIC_FEATURE_ENABLED": "true",
+        "DYNAMIC_FEATURE_VARIABLE": "dynamic variable"
       }
     }
   }

--- a/EnvVariables/EnvVariables/Properties/launchSettings.json
+++ b/EnvVariables/EnvVariables/Properties/launchSettings.json
@@ -11,7 +11,8 @@
         "REQUIRED_VARIABLE": "required variable value",
         "NOT_REQUIRED_VARIABLE": "not required variable value",
         "SOME_FEATURE_ENABLED": "true",
-        "FEATURE_VARIABLE": "feature var"
+        "FEATURE_VARIABLE": "feature var",
+        "ONE_MORE_VARIABLE": "ONE_MORE"
       }
     }
   }

--- a/EnvVariables/EnvVariables/Properties/launchSettings.json
+++ b/EnvVariables/EnvVariables/Properties/launchSettings.json
@@ -1,0 +1,18 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5206",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "REQUIRED_VARIABLE": "required variable value",
+        "NOT_REQUIRED_VARIABLE": "not required variable value",
+        "SOME_FEATURE_ENABLED": "true",
+        "FEATURE_VARIABLE": "feature var"
+      }
+    }
+  }
+}

--- a/EnvVariables/EnvVariables/appsettings.json
+++ b/EnvVariables/EnvVariables/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "my": {
+    "deep": {
+      "section": {
+        "additionalPropertyAlsoWorks": 1
+      }
+    },
+    "additionalPropertyAlsoWorks": 2,
+    "some": {
+      "feature": {
+        "name": "billing"
+      }
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/EnvVariables/EnvVariables/envs.json
+++ b/EnvVariables/EnvVariables/envs.json
@@ -1,0 +1,49 @@
+[
+  {
+    "Name": "REQUIRED_VARIABLE",
+    "Description": "Example of required variable",
+    "PopulateTo": [
+      "my:deep:section:value",
+      "my:deep:anotherSection:value"
+    ],
+    "Required": true,
+    "DefaultValue": null
+  },
+  {
+    "Name": "NOT_REQUIRED_VARIABLE",
+    "Description": "Example of optional variable",
+    "PopulateTo": [
+      "top_level_value"
+    ],
+    "Required": false,
+    "DefaultValue": null
+  },
+  {
+    "Name": "STATIC_FEATURE_VARIABLE",
+    "Description": "static env variable",
+    "PopulateTo": [
+      "some:static_feature:value",
+      "some:static_feature:value2"
+    ],
+    "Required": true,
+    "DefaultValue": null
+  },
+  {
+    "Name": "ONE_MORE_VARIABLE",
+    "Description": "one more!",
+    "PopulateTo": [
+      "one:more:section:value"
+    ],
+    "Required": true,
+    "DefaultValue": null
+  },
+  {
+    "Name": "DYNAMIC_FEATURE_VARIABLE",
+    "Description": "Dynamic feature variable",
+    "PopulateTo": [
+      "some:dynamic_feature:value"
+    ],
+    "Required": false,
+    "DefaultValue": null
+  }
+]


### PR DESCRIPTION
How to use this:

At startup you should describe all envs that required to run application https://github.com/mt89vein/dotnet-tips/compare/master...envs?expand=1#diff-4a749835d64f44bf1d9c66b8866be2a54489b31ec231d4cf33f9de58446caa18R65

Envs may be optional, required or may be used only when feature enabled or not.

Then envs via ConfigurationProvider maps to another configuration sections that configured previously. So it very easy to substitute them where they need. 

You can inherit from EnvVariable class or define own validation logic via it's ctor: https://github.com/mt89vein/dotnet-tips/compare/master...envs?expand=1#diff-df9b6aeeea4ce2b5f996f4d6608c1223f05997eda38f28bde4bd7b28cbfd5335R33

To show all configured envs, you can run app using "dotnet run -- print-envs", or save it to json faile via command "dotnet run -- save-envs"